### PR TITLE
Feat - Migrate from `ioredis` to `node-redis`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.10",
-        "@nestjs/schematics": "^10.0.0",
+        "@nestjs/schematics": "^10.2.3",
         "@nestjs/testing": "^10.0.0",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
@@ -59,15 +59,16 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.1.2.tgz",
-      "integrity": "sha512-ku+/W/HMCBacSWFppenr9y6Lx8mDuTuQvn1IkTyBLiJOpWnzgVbx9kHDeaDchGa1PwLlJUBBrv27t3qgJOIDPw==",
+      "version": "17.3.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.11.tgz",
+      "integrity": "sha512-vTNDYNsLIWpYk2I969LMQFH29GTsLzxNk/0cLw5q56ARF0v5sIWfHYwGTS88jdDqIpuuettcSczbxeA7EuAmqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "8.12.0",
         "ajv-formats": "2.1.1",
-        "jsonc-parser": "3.2.0",
-        "picomatch": "3.0.1",
+        "jsonc-parser": "3.2.1",
+        "picomatch": "4.0.1",
         "rxjs": "7.8.1",
         "source-map": "0.7.4"
       },
@@ -85,15 +86,23 @@
         }
       }
     },
-    "node_modules/@angular-devkit/schematics": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.1.2.tgz",
-      "integrity": "sha512-8S9RuM8olFN/gwN+mjbuF1CwHX61f0i59EGXz9tXLnKRUTjsRR+8vVMTAmX0dvVAT5fJTG/T69X+HX7FeumdqA==",
+    "node_modules/@angular-devkit/core/node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@angular-devkit/schematics": {
+      "version": "17.3.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.3.11.tgz",
+      "integrity": "sha512-I5wviiIqiFwar9Pdk30Lujk8FczEEc18i22A5c6Z9lbmhPQdTroDnEQdsfXjy404wPe8H62s0I15o4pmMGfTYQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "17.1.2",
-        "jsonc-parser": "3.2.0",
-        "magic-string": "0.30.5",
+        "@angular-devkit/core": "17.3.11",
+        "jsonc-parser": "3.2.1",
+        "magic-string": "0.30.8",
         "ora": "5.4.1",
         "rxjs": "7.8.1"
       },
@@ -238,13 +247,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/schematics-cli/node_modules/jsonc-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@angular-devkit/schematics-cli/node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -267,6 +269,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -2107,30 +2116,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@nestjs/cli/node_modules/comment-json": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
-      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-timsort": "^1.0.3",
-        "core-util-is": "^1.0.3",
-        "esprima": "^4.0.1",
-        "has-own-prop": "^2.0.0",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@nestjs/cli/node_modules/jsonc-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@nestjs/cli/node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -2291,26 +2276,21 @@
       "license": "0BSD"
     },
     "node_modules/@nestjs/schematics": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.1.1.tgz",
-      "integrity": "sha512-o4lfCnEeIkfJhGBbLZxTuVWcGuqDCFwg5OrvpgRUBM7vI/vONvKKiB5riVNpO+JqXoH0I42NNeDb0m4V5RREig==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.2.3.tgz",
+      "integrity": "sha512-4e8gxaCk7DhBxVUly2PjYL4xC2ifDFexCqq1/u4TtivLGXotVk0wHdYuPYe1tHTHuR1lsOkRbfOCpkdTnigLVg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "17.1.2",
-        "@angular-devkit/schematics": "17.1.2",
-        "comment-json": "4.2.3",
-        "jsonc-parser": "3.2.1",
+        "@angular-devkit/core": "17.3.11",
+        "@angular-devkit/schematics": "17.3.11",
+        "comment-json": "4.2.5",
+        "jsonc-parser": "3.3.1",
         "pluralize": "8.0.0"
       },
       "peerDependencies": {
         "typescript": ">=4.8.2"
       }
-    },
-    "node_modules/@nestjs/schematics/node_modules/jsonc-parser": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
-      "dev": true
     },
     "node_modules/@nestjs/testing": {
       "version": "10.3.8",
@@ -4120,10 +4100,11 @@
       }
     },
     "node_modules/comment-json": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.3.tgz",
-      "integrity": "sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
+      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.3",
@@ -6931,10 +6912,11 @@
       }
     },
     "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -7062,10 +7044,11 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
-      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -7716,12 +7699,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.1.tgz",
+      "integrity": "sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
         "@nestjs/platform-express": "^10.0.0",
         "axios": "^1.7.9",
         "fluent-ffmpeg": "^2.1.3",
-        "ioredis": "^5.4.1",
         "openai": "^4.47.1",
+        "redis": "^5.8.1",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1"
       },
@@ -1313,11 +1313,6 @@
         }
       }
     },
-    "node_modules/@ioredis/commands": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
-    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -2429,6 +2424,66 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.8.1.tgz",
+      "integrity": "sha512-hJOJr/yX6BttnyZ+nxD3Ddiu2lPig4XJjyAK1v7OSHOJNUTfn3RHBryB9wgnBMBdkg9glVh2AjItxIXmr600MA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.1"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.8.1.tgz",
+      "integrity": "sha512-hD5Tvv7G0t8b3w8ao3kQ4jEPUmUUC6pqA18c8ciYF5xZGfUGBg0olQHW46v6qSt4O5bxOuB3uV7pM6H5wEjBwA==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.8.1.tgz",
+      "integrity": "sha512-kyvM8Vn+WjJI++nRsIoI9TbdfCs1/TgD0Hp7Z7GiG6W4IEBzkXGQakli+R5BoJzUfgh7gED2fkncYy1NLprMNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.1"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.8.1.tgz",
+      "integrity": "sha512-CzuKNTInTNQkxqehSn7QiYcM+th+fhjQn5ilTvksP1wPjpxqK0qWt92oYg3XZc3tO2WuXkqDvTujc4D7kb6r/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.1"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.8.1.tgz",
+      "integrity": "sha512-klvdR96U9oSOyqvcectoAGhYlMOnMS3I5UWUOgdBn1buMODiwM/E4Eds7gxldKmtowe4rLJSF1CyIqyZTjy8Ow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.8.1"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4007,6 +4062,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
       "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4253,6 +4309,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4328,14 +4385,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -5920,29 +5969,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/ioredis": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
-      "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
-      "dependencies": {
-        "@ioredis/commands": "^1.1.1",
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.4",
-        "denque": "^2.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.isarguments": "^3.1.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ioredis"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6998,16 +7024,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
-    },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8000,23 +8016,20 @@
         "node": ">= 6"
       }
     },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+    "node_modules/redis": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.8.1.tgz",
+      "integrity": "sha512-RZjBKYX/qFF809x6vDcE5VA6L3MmiuT+BkbXbIyyyeU0lPD47V4z8qTzN+Z/kKFwpojwCItOfaItYuAjNs8pTQ==",
+      "license": "MIT",
       "dependencies": {
-        "redis-errors": "^1.0.0"
+        "@redis/bloom": "5.8.1",
+        "@redis/client": "5.8.1",
+        "@redis/json": "5.8.1",
+        "@redis/search": "5.8.1",
+        "@redis/time-series": "5.8.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">= 18"
       }
     },
     "node_modules/reflect-metadata": {
@@ -8473,11 +8486,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/standard-as-callback": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "@nestjs/platform-express": "^10.0.0",
     "axios": "^1.7.9",
     "fluent-ffmpeg": "^2.1.3",
-    "ioredis": "^5.4.1",
     "openai": "^4.47.1",
+    "redis": "^5.8.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.10",
-    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/schematics": "^10.2.3",
     "@nestjs/testing": "^10.0.0",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { OpenaiModule } from './openai/openai.module';
 import { UserContextModule } from './user-context/user-context.module';
 import { StabilityaiModule } from './stabilityai/stabilityai.module';
 import { AudioModule } from './audio/audio.module';
+import { RedisProvider } from './redis/redis.provider';
 
 @Module({
   imports: [
@@ -18,6 +19,6 @@ import { AudioModule } from './audio/audio.module';
     AudioModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, RedisProvider],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,13 +1,10 @@
 import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
 import { WhatsappModule } from './whatsapp/whatsapp.module';
 import { ConfigModule } from '@nestjs/config';
 import { OpenaiModule } from './openai/openai.module';
 import { UserContextModule } from './user-context/user-context.module';
 import { StabilityaiModule } from './stabilityai/stabilityai.module';
 import { AudioModule } from './audio/audio.module';
-import { RedisProvider } from './redis/redis.provider';
 
 @Module({
   imports: [
@@ -18,7 +15,5 @@ import { RedisProvider } from './redis/redis.provider';
     StabilityaiModule,
     AudioModule,
   ],
-  controllers: [AppController],
-  providers: [AppService, RedisProvider],
 })
 export class AppModule {}

--- a/src/redis/redis.provider.spec.ts
+++ b/src/redis/redis.provider.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RedisProvider } from './redis.provider';
+
+describe('Redis', () => {
+  let provider: RedisProvider;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RedisProvider],
+    }).compile();
+
+    provider = module.get<RedisProvider>(RedisProvider);
+  });
+
+  it('should be defined', () => {
+    expect(provider).toBeDefined();
+  });
+});

--- a/src/redis/redis.provider.ts
+++ b/src/redis/redis.provider.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { createClient, RedisClientType } from 'redis';
+
+@Injectable()
+export class RedisProvider implements OnModuleInit {
+  private readonly logger = new Logger(RedisProvider.name);
+  private readonly redisClient: RedisClientType;
+
+  constructor() {
+    this.redisClient = createClient({
+      url: process.env.REDIS_URL || 'redis://localhost:6379',
+      socket: {
+        reconnectStrategy: (retries) => {
+          if (retries > 40) {
+            this.logger.error(
+              'Too many retries, Redis connection will be terminated',
+            );
+            return new Error('Too many retries.');
+          }
+          return Math.min(retries * 500, 5000);
+        },
+        connectTimeout: 10000,
+      },
+    });
+
+    this.redisClient.on('error', (error) => {
+      this.logger.error(`Redis client error: ${error.message}`, error);
+    });
+  }
+
+  async onModuleInit() {
+    await this.redisClient.connect();
+    this.logger.log('Connected to Redis');
+  }
+
+  getClient(): RedisClientType {
+    return this.redisClient;
+  }
+}

--- a/src/user-context/user-context.module.ts
+++ b/src/user-context/user-context.module.ts
@@ -1,7 +1,10 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { UserContextService } from './user-context.service';
+import { RedisProvider } from 'src/redis/redis.provider';
 
+@Global()
 @Module({
-  providers: [UserContextService]
+  providers: [UserContextService, RedisProvider],
+  exports: [RedisProvider],
 })
 export class UserContextModule {}

--- a/src/user-context/user-context.service.ts
+++ b/src/user-context/user-context.service.ts
@@ -64,9 +64,13 @@ export class UserContextService {
         .expire(hashedUserID, this.contextExpirationTime)
         .exec(); // We're executing both operations in a single round-trip
 
-      const conversationContext = results[1][1] as string[];
+      const lRangeResult = results[1];
+      if (Array.isArray(lRangeResult)) {
+        const conversationContext = lRangeResult as string[];
+        return conversationContext.map((item) => JSON.parse(item));
+      }
 
-      return conversationContext.map((item) => JSON.parse(item));
+      return [];
     } catch (error) {
       this.logger.error('Error Saving Context And Retrieving', error);
       return [];

--- a/src/whatsapp/whatsapp.module.ts
+++ b/src/whatsapp/whatsapp.module.ts
@@ -2,9 +2,9 @@ import { Module } from '@nestjs/common';
 import { WhatsappController } from './whatsapp.controller';
 import { WhatsappService } from './whatsapp.service';
 import { OpenaiService } from 'src/openai/openai.service';
-import { UserContextService } from '../user-context/user-context.service';
-import { StabilityaiService } from '../stabilityai/stabilityai.service';
-import { AudioService } from '../audio/audio.service';
+import { UserContextService } from 'src/user-context/user-context.service';
+import { StabilityaiService } from 'src/stabilityai/stabilityai.service';
+import { AudioService } from 'src/audio/audio.service';
 
 @Module({
   controllers: [WhatsappController],


### PR DESCRIPTION
## Description

Migrate Redis client from **ioredis** to **node-redis** to prepare for embedding storage and retrieval via **Redis Vector Search** and improve maintainability.

### Why

* `ioredis` lacks built-in Redis Stack support (Vector Search/RediSearch); requires low-level `.call()` usage.
* `node-redis` (official) provides first-class support for RediSearch/Vector Search, future-proofing the codebase.

### What changed

* Replaced `ioredis` with `node-redis`.
* Updated commands to **camelCase** (`lrange → lRange`, `hset → hSet`, `setex → setEx`, etc.).
* Exposed a single app-wide Redis client via `RedisProvider` (owned by `UserContextModule`, marked `@Global()`), preventing duplicate connections/logs.

### Impact / Migration notes

* **Potentially breaking:** update any remaining snake\_case calls to camelCase.
* Remove any direct `.call()` usages in favor of `node-redis` APIs (e.g., `ft.*`).
* Ensure `REDIS_URL` (or `rediss://` for TLS) is set.

### Verification

* App startup shows **one** “Connected to Redis” log.
* Basic reads/writes succeed; RediSearch/Vector Search commands available for embeddings.
